### PR TITLE
Use Dictionary in Storage binding instead of Map.

### DIFF
--- a/bindings/src/main/scala/chrome/storage/Storage.scala
+++ b/bindings/src/main/scala/chrome/storage/Storage.scala
@@ -14,9 +14,9 @@ object Storage extends ChromeAPI {
   implicit class StorageArea(area: bindings.StorageArea) {
 
     def get(keys: js.UndefOr[js.Any] = js.undefined)
-      : Future[Map[String, js.Any]] = {
-      val promise = Promise[Map[String, js.Any]]()
-      area.get(keys, (results: Map[String, js.Any]) => {
+      : Future[js.Dictionary[js.Any]] = {
+      val promise = Promise[js.Dictionary[js.Any]]()
+      area.get(keys, (results: js.Dictionary[js.Any]) => {
         promise.complete(lastErrorOrValue(results))
       })
       promise.future
@@ -30,7 +30,7 @@ object Storage extends ChromeAPI {
       promise.future
     }
 
-    def set(items: Map[String, js.Any]): Future[Unit] = {
+    def set(items: js.Dictionary[js.Any]): Future[Unit] = {
       val promise = Promise[Unit]()
       area.set(items, js.Any.fromFunction0(() => {
         promise.complete(lastErrorOrValue(()))

--- a/bindings/src/main/scala/chrome/storage/bindings/Storage.scala
+++ b/bindings/src/main/scala/chrome/storage/bindings/Storage.scala
@@ -17,10 +17,10 @@ trait StorageChange extends js.Object {
 trait StorageArea extends js.Object {
 
   def get(keys: js.UndefOr[js.Any] = js.undefined,
-          callback: js.Function1[Map[String, js.Any], _]): Unit = js.native
+          callback: js.Function1[js.Dictionary[js.Any], _]): Unit = js.native
   def getBytesInUse(keys: js.UndefOr[js.Any] = js.undefined,
                     callback: js.Function1[Int, _]): Unit = js.native
-  def set(items: Map[String, js.Any],
+  def set(items: js.Dictionary[js.Any],
           callback: js.UndefOr[js.Function0[_]] = js.undefined): Unit =
     js.native
   def remove(keys: js.Any,


### PR DESCRIPTION
In the Storage binding, the actual runtime type of storage values is js.Dictionary, not a Map(currently it fails in runtime with cast exception). This PR fixes the problem.