### PR TITLE
Bump Scala.js version to 0.6.21

### DIFF
--- a/bindings/src/main/scala/chrome/contextMenus/bindings/ContextMenus.scala
+++ b/bindings/src/main/scala/chrome/contextMenus/bindings/ContextMenus.scala
@@ -4,7 +4,7 @@ import chrome.events.bindings.Event
 import chrome.tabs.bindings.Tab
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.{JSGlobal, ScalaJSDefined}
+import scala.scalajs.js.annotation.JSGlobal
 import scala.scalajs.js.|
 
 object MenuContexts {
@@ -46,7 +46,6 @@ object ContextMenus extends js.Object {
 
 }
 
-@ScalaJSDefined
 class UpdateProperties(
     val `type`: String = MenuType.NORMAL,
     val title: String,
@@ -68,7 +67,6 @@ object CreateProperties {
     new CreateProperties(id = id, title = title, contexts = contexts)
 }
 
-@ScalaJSDefined
 class CreateProperties(
     val `type`: String = MenuType.NORMAL,
     val id: String | Int,

--- a/bindings/src/main/scala/chrome/pageAction/bindings/PageAction.scala
+++ b/bindings/src/main/scala/chrome/pageAction/bindings/PageAction.scala
@@ -5,7 +5,7 @@ import chrome.pageAction.bindings.PageAction.ImageDataType
 import chrome.tabs.bindings.Tab
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.{JSGlobal, ScalaJSDefined}
+import scala.scalajs.js.annotation.JSGlobal
 import scala.scalajs.js.|
 
 @js.native
@@ -40,7 +40,6 @@ object PageAction extends js.Object {
     js.native
 }
 
-@ScalaJSDefined
 class GetPopupDetails(val tabId: Tab.Id) extends js.Object
 
 object GetPopupDetails {
@@ -49,7 +48,6 @@ object GetPopupDetails {
     new GetPopupDetails(tabId)
 }
 
-@ScalaJSDefined
 class GetTitleDetails(val tabId: Tab.Id) extends js.Object
 
 object GetTitleDetails {
@@ -58,7 +56,6 @@ object GetTitleDetails {
     new GetTitleDetails(tabId)
 }
 
-@ScalaJSDefined
 class SetIconDetails(
   val tabId: Tab.Id,
   val imageData: js.UndefOr[ImageDataType | js.Dictionary[ImageDataType]],
@@ -74,7 +71,6 @@ object SetIconDetails {
   ): SetIconDetails = new SetIconDetails(tabId, imageData, path)
 }
 
-@ScalaJSDefined
 class SetPopupDetails(val tabId: Tab.Id, val popup: String) extends js.Object
 
 object SetPopupDetails {
@@ -83,7 +79,6 @@ object SetPopupDetails {
     new SetPopupDetails(tabId, popup)
 }
 
-@ScalaJSDefined
 class SetTitleDetails(val tabId: Tab.Id, val title: String) extends js.Object
 
 object SetTitleDetails {

--- a/bindings/src/main/scala/chrome/utils/ChromeApp.scala
+++ b/bindings/src/main/scala/chrome/utils/ChromeApp.scala
@@ -3,11 +3,9 @@ package chrome.utils
 import chrome.app.runtime.Runtime
 import chrome.app.runtime.bindings.{LaunchData, Request}
 
-import scala.scalajs.js
+trait ChromeApp {
 
-trait ChromeApp extends js.JSApp {
-
-  def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     Runtime.onLaunched.listen(onLaunched)
     Runtime.onRestarted.listen((_) => onRestart)
     Runtime.onEmbedRequested.listen(onEmbedRequested)

--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,8 @@ lazy val bindings = project.in(file("bindings"))
   .settings(commonSettings: _*)
   .settings(
     name := "scala-js-chrome",
-    scalaVersion := "2.12.2",
-    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2"),
+    scalaVersion := "2.12.4",
+    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4"),
     libraryDependencies ++= Seq(
       "org.scala-js" %%% "scalajs-dom" % "0.9.4"
     ),
@@ -77,8 +77,8 @@ lazy val monixInterop = project.in(file("interop/monix")).
   settings(commonSettings: _*).
   settings(
     name := "scala-js-chrome-monix",
-    scalaVersion := "2.12.2",
-    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2"),
+    scalaVersion := "2.12.4",
+    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4"),
     libraryDependencies ++= Seq(
       "io.monix" %%% "monix" % "2.2.4"
     ),
@@ -96,8 +96,8 @@ lazy val fs2Interop = project.in(file("interop/fs2")).
   settings(commonSettings: _*).
   settings(
     name := "scala-js-chrome-fs2",
-    scalaVersion := "2.12.2",
-    crossScalaVersions := Seq("2.11.11", "2.12.2"),
+    scalaVersion := "2.12.4",
+    crossScalaVersions := Seq("2.11.11", "2.12.4"),
     libraryDependencies ++= Seq(
       "co.fs2" %%% "fs2-core" % "0.9.7"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val plugin = project.in(file("sbt-plugin")).
     publishMavenStyle := false,
     bintrayRepository := "sbt-plugins",
     bintrayOrganization := None,
-    addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
+    addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
   ).
   enablePlugins(commonPlugins: _*)
 

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val fs2Interop = project.in(file("interop/fs2")).
     scalaVersion := "2.12.2",
     crossScalaVersions := Seq("2.11.11", "2.12.2"),
     libraryDependencies ++= Seq(
-      "co.fs2" %%% "fs2-core" % "0.9.5"
+      "co.fs2" %%% "fs2-core" % "0.9.7"
     ),
     publishMavenStyle := true,
     publishTo := {

--- a/build.sbt
+++ b/build.sbt
@@ -32,24 +32,23 @@ lazy val commonSettings = Seq(
 
 lazy val commonPlugins = Seq(GitVersioning)
 
-
-lazy val bindings = project.in(file("bindings")).
-  settings(commonSettings: _*).
-  settings(
+lazy val bindings = project.in(file("bindings"))
+  .settings(commonSettings: _*)
+  .settings(
     name := "scala-js-chrome",
     scalaVersion := "2.12.2",
     crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2"),
     libraryDependencies ++= Seq(
-      "org.scala-js" %%% "scalajs-dom" % "0.9.1"
+      "org.scala-js" %%% "scalajs-dom" % "0.9.4"
     ),
     publishMavenStyle := true,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (isSnapshot.value)
-        Some("snapshots" at nexus + "content/repositories/snapshots")
-      else
-        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-    }
+      if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+      else Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    },
+    scalacOptions += "-P:scalajs:sjsDefinedByDefault",
+    scalaJSUseMainModuleInitializer := true
   ).
   enablePlugins(commonPlugins: _*).
   enablePlugins(ScalaJSPlugin)
@@ -60,7 +59,7 @@ lazy val plugin = project.in(file("sbt-plugin")).
     sbtPlugin := true,
     name := "sbt-chrome-plugin",
     libraryDependencies ++= {
-      val circeVersion = "0.8.0"
+      val circeVersion = "0.9.0"
       Seq(
         "io.circe" %% "circe-core"    % circeVersion,
         "io.circe" %% "circe-generic" % circeVersion,
@@ -74,8 +73,6 @@ lazy val plugin = project.in(file("sbt-plugin")).
   ).
   enablePlugins(commonPlugins: _*)
 
-
-
 lazy val monixInterop = project.in(file("interop/monix")).
   settings(commonSettings: _*).
   settings(
@@ -88,10 +85,8 @@ lazy val monixInterop = project.in(file("interop/monix")).
     publishMavenStyle := true,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (isSnapshot.value)
-        Some("snapshots" at nexus + "content/repositories/snapshots")
-      else
-        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+      if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+      else                  Some("releases"  at nexus + "service/local/staging/deploy/maven2")
     }
   ).dependsOn(bindings)
    .enablePlugins(commonPlugins: _*)
@@ -109,10 +104,8 @@ lazy val fs2Interop = project.in(file("interop/fs2")).
     publishMavenStyle := true,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (isSnapshot.value)
-        Some("snapshots" at nexus + "content/repositories/snapshots")
-      else
-        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+      if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+      else                  Some("releases"  at nexus + "service/local/staging/deploy/maven2")
     }
   ).dependsOn(bindings)
   .enablePlugins(commonPlugins: _*)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 1.0.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.4
+sbt.version = 1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
-// addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.1.0") find this plugin later
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+// addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.1.0") find this plugin later
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"

--- a/sbt-plugin/src/main/scala/net/lullabyte/Chrome.scala
+++ b/sbt-plugin/src/main/scala/net/lullabyte/Chrome.scala
@@ -1,9 +1,8 @@
 package net.lullabyte
 
-import chrome.{App, AppManifest, Background, ExtensionManifest}
 import chrome.Manifest
-import chrome.permissions.Permission.{API, Host}
 import io.circe.Printer
+import io.circe.syntax._
 import sbt._
 
 object Chrome {
@@ -30,15 +29,15 @@ object Chrome {
       (jsLib, unpacked / mainFileName),
       (jsDeps, unpacked / dependenciesFileName),
       (manifest, unpacked / "manifest.json")
-    ), overwrite = true, preserveLastModified = true)
+    ), overwrite = true, preserveLastModified = true, preserveExecutable = true)
     unpacked
   }
 
-  val printer = Printer.noSpaces.copy(dropNullKeys = true)
+  val printer = Printer.noSpaces.copy(dropNullValues = true)
 
   def generateManifest(out: File)(manifest: Manifest): File = {
     import JsonCodecs._
-    import io.circe.syntax._
+
     val content = printer.pretty(manifest.asJson)
     IO.write(out, content)
     out

--- a/sbt-plugin/src/main/scala/net/lullabyte/ChromeSbtPlugin.scala
+++ b/sbt-plugin/src/main/scala/net/lullabyte/ChromeSbtPlugin.scala
@@ -2,7 +2,6 @@ package net.lullabyte
 
 import chrome.Manifest
 import org.scalajs.sbtplugin.ScalaJSPlugin
-
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import sbt.Keys._
 import sbt._
@@ -49,7 +48,7 @@ object ChromeSbtPlugin extends AutoPlugin {
           ".DS_Store"
         )
         val fileFilter = AllPassFilter - new SimpleFilter(excludeFileNames.contains)
-        IO.zip(selectSubpaths(chromeAppDir, fileFilter), zipFile)
+        IO.zip(Path.selectSubpaths(chromeAppDir, fileFilter), zipFile)
         zipFile
       },
       chromeGenerateManifest := {

--- a/sbt-plugin/src/main/scala/net/lullabyte/JsonCodecs.scala
+++ b/sbt-plugin/src/main/scala/net/lullabyte/JsonCodecs.scala
@@ -2,9 +2,7 @@ package net.lullabyte
 
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.semiauto._
 import chrome._
-import chrome.Commands._
 import chrome.permissions.Permission.{API, Host}
 
 object JsonCodecs {


### PR DESCRIPTION
1, Updated SBT to 1.1.0 #33 
2, Bumped Scala.js version to 0.6.21
3. Fixed Scala.js deprecation errors.
4. Updated sbt plugins.