### PR TITLE
Add Content Security Policy (CSP) support to manifest

### DIFF
--- a/bindings/src/main/scala/chrome/runtime/Runtime.scala
+++ b/bindings/src/main/scala/chrome/runtime/Runtime.scala
@@ -140,6 +140,7 @@ object Runtime {
         override val offlineEnabled = manifest.offlineEnabled.toOption
         override val permissions = perms
         override val icons = iconsValue
+        override val contentSecurityPolicy = manifest.content_security_policy.toOption
       }
     } else {
       val extension = manifest.asExtensionManifest.get
@@ -157,6 +158,7 @@ object Runtime {
             scripts =
               extension.background.map(_.scripts.toList).getOrElse(List())
         )
+        override val contentSecurityPolicy = manifest.content_security_policy.toOption
       }
     }
   }

--- a/bindings/src/main/scala/chrome/runtime/bindings/Manifest.scala
+++ b/bindings/src/main/scala/chrome/runtime/bindings/Manifest.scala
@@ -34,6 +34,7 @@ trait Manifest extends js.Object {
   val offlineEnabled: js.UndefOr[Boolean] = js.native
   val permissions: js.UndefOr[js.Array[String]] = js.native
   val icons: js.UndefOr[Map[String, String]] = js.native
+  val content_security_policy: js.UndefOr[String] = js.native
 
 }
 

--- a/sbt-plugin/src/main/scala/net/lullabyte/JsonCodecs.scala
+++ b/sbt-plugin/src/main/scala/net/lullabyte/JsonCodecs.scala
@@ -177,7 +177,8 @@ object JsonCodecs {
           case API(name) => Json.fromString(name)
           case Host(url) => Json.fromString(url)
         }
-      )
+      ),
+      ("content_security_policy", manifest.contentSecurityPolicy.asJson)
     )
   }
 

--- a/shared/src/main/scala/chrome/Manifest.scala
+++ b/shared/src/main/scala/chrome/Manifest.scala
@@ -24,6 +24,7 @@ sealed trait Manifest {
   val externallyConnectable: Option[ExternallyConnectable] = None
   val oauth2: Option[Oauth2Settings] = None
   val webAccessibleResources: List[String] = Nil
+  val contentSecurityPolicy: Option[String] = None
 }
 
 case class Background(scripts: List[String])


### PR DESCRIPTION
Add support for Content Security Policy (CSP) to manifest.
Required when loading and executing external resources (e.g js libs) that cannot be embedded.

Refs:
https://developer.chrome.com/extensions/contentSecurityPolicy
https://developer.chrome.com/apps/contentSecurityPolicy
