### PR TITLE
I18N multiple substitutions support

### DIFF
--- a/bindings/src/main/scala/chrome/i18n/I18N.scala
+++ b/bindings/src/main/scala/chrome/i18n/I18N.scala
@@ -4,6 +4,9 @@ import scala.concurrent.{Future, Promise}
 import scala.scalajs.js
 import chrome.utils.ErrorHandling._
 
+import js.JSConverters._
+import scala.scalajs.js.|
+
 object I18N {
 
   def getAcceptLanguages: Future[js.Array[String]] = {
@@ -14,9 +17,14 @@ object I18N {
     promise.future
   }
 
-  def getMessage(messageName: String,
-                 substitutions: String*): js.UndefOr[String] =
-    bindings.I18N.getMessage(messageName, substitutions: _*)
+  def getMessage(messageName: String, substitutions: String*): js.UndefOr[String] = {
+    if(substitutions.isEmpty) {
+      bindings.I18N.getMessage(messageName)
+    } else {
+      val jsArraySubstitutions = substitutions.toJSArray.asInstanceOf[String | js.Array[String]]
+      bindings.I18N.getMessage(messageName, Some(jsArraySubstitutions).orUndefined)
+    }
+  }
 
   def getUILanguage: String = bindings.I18N.getUILanguage()
 

--- a/bindings/src/main/scala/chrome/i18n/bindings/I18N.scala
+++ b/bindings/src/main/scala/chrome/i18n/bindings/I18N.scala
@@ -2,6 +2,7 @@ package chrome.i18n.bindings
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
+import scala.scalajs.js.|
 
 @js.native
 @JSGlobal("chrome.i18n")
@@ -11,7 +12,7 @@ object I18N extends js.Object {
     js.native
 
   def getMessage(messageName: String,
-                 substitutions: String*): js.UndefOr[String] = js.native
+                 substitutions: js.UndefOr[String | js.Array[String]] = js.undefined): js.UndefOr[String] = js.native
 
   def getUILanguage(): String = js.native
 


### PR DESCRIPTION
Chrome I18N getMessage does not support (anymore ?) string varargs for substitutions and requires an array for multiple substitutions.

Support for 0 and 1 substitution is already provided.
This PR adds support for 2 and more substitutions.
According to the docs https://developer.chrome.com/extensions/i18n#method-getMessage there is a limit of 9 substitutions in the array (this check is not enforced by this PR).

The API supports:
- No argument
- String
- String array

I18N.getMessage signature is unchanged
bindings.I18N.getMessage signature is updated
