### PR TITLE
Add source map support

### DIFF
--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -26,12 +26,28 @@ lazy val exampleApp = project.in(file("app"))
     scalaJSUseMainModuleInitializer in Test := false,
     relativeSourceMaps := true,
     skip in packageJSDependencies := false,
+
+    // you can customize and have a static output name for lib and dependencies
+    // instead of having the default files names like app-fastopt.js, ...
+    artifactPath in (Compile, fastOptJS) := {
+      (crossTarget in fastOptJS).value / "main.js"
+    },
+    artifactPath in (Compile, fullOptJS) := {
+      (crossTarget in fullOptJS).value / "main.js"
+    },
+    artifactPath in (Compile, packageJSDependencies) := {
+      (crossTarget in packageJSDependencies).value / "dependencies.js"
+    },
+    artifactPath in (Compile, packageMinifiedJSDependencies) := {
+      (crossTarget in packageMinifiedJSDependencies).value / "dependencies.js"
+    },
+
     chromeManifest := new AppManifest {
       val name = Keys.name.value
       val version = Keys.version.value
       val app = App(
         background = Background(
-          scripts = Chrome.defaultScripts
+          scripts = List("main.js", "dependencies.js")
         )
       )
       override val defaultLocale = Some("en")
@@ -71,9 +87,25 @@ lazy val extension = project.in(file("extension"))
     scalaJSUseMainModuleInitializer in Test := false,
     relativeSourceMaps := true,
     skip in packageJSDependencies := false,
+
+    // you can customize and have a static output name for lib and dependencies
+    // instead of having the default files names like extension-fastopt.js, ...
+    artifactPath in (Compile, fastOptJS) := {
+      (crossTarget in fastOptJS).value / "main.js"
+    },
+    artifactPath in (Compile, fullOptJS) := {
+      (crossTarget in fullOptJS).value / "main.js"
+    },
+    artifactPath in (Compile, packageJSDependencies) := {
+      (crossTarget in packageJSDependencies).value / "dependencies.js"
+    },
+    artifactPath in (Compile, packageMinifiedJSDependencies) := {
+      (crossTarget in packageMinifiedJSDependencies).value / "dependencies.js"
+    },
+
     chromeManifest := new ExtensionManifest {
       val background = Background(
-        scripts = Chrome.defaultScripts
+        scripts = List("main.js", "dependencies.js")
       )
       val name = Keys.name.value
       val version = Keys.version.value

--- a/sbt-plugin/src/main/scala/net/lullabyte/ChromeSbtPlugin.scala
+++ b/sbt-plugin/src/main/scala/net/lullabyte/ChromeSbtPlugin.scala
@@ -20,11 +20,12 @@ object ChromeSbtPlugin extends AutoPlugin {
     val fullOptJsLib = TaskKey[Attributed[File]]("fullOptJsLib")
     val fastOptJsLib = TaskKey[Attributed[File]]("fastOptJsLib")
 
+    private val chromeDir = "chrome"
 
     lazy val baseSettings: Seq[Def.Setting[_]] = Seq(
       fastOptJsLib := (fastOptJS in Compile).value,
       chromeUnpackedFast := {
-        Chrome.buildUnpackedDirectory(target.value / "chrome" / "unpacked-fast")(
+        Chrome.buildUnpackedDirectory(target.value / chromeDir / "unpacked-fast")(
           (chromeGenerateManifest in Compile).value,
           fastOptJsLib.value.data,
           (packageJSDependencies in Compile).value,
@@ -33,7 +34,7 @@ object ChromeSbtPlugin extends AutoPlugin {
       },
       fullOptJsLib := (fullOptJS in Compile).value,
       chromeUnpackedOpt := {
-        Chrome.buildUnpackedDirectory(target.value / "chrome" / "unpacked-opt")(
+        Chrome.buildUnpackedDirectory(target.value / chromeDir / "unpacked-opt")(
           (chromeGenerateManifest in Compile).value,
           fullOptJsLib.value.data,
           (packageMinifiedJSDependencies in Compile).value,
@@ -41,7 +42,7 @@ object ChromeSbtPlugin extends AutoPlugin {
         )
       },
       chromePackage := {
-        val out = target.value / "chrome"
+        val out = target.value / chromeDir
         val chromeAppDir = chromeUnpackedOpt.value
         val zipFile = new File(out, s"${name.value}.zip")
         val excludeFileNames = Set(
@@ -52,7 +53,7 @@ object ChromeSbtPlugin extends AutoPlugin {
         zipFile
       },
       chromeGenerateManifest := {
-        Chrome.generateManifest(target.value / "chrome" / "generated_manifest.json")(
+        Chrome.generateManifest(target.value / chromeDir / "generated_manifest.json")(
           (chromeManifest in Compile).value
         )
       }


### PR DESCRIPTION
Source maps are very useful to debug applications and this PR adds support for them.

Default ScalaJSPlugin generates the source map for the compiled lib, but it is not supported in the chrome unpacked build.

The problem encountered:
- source map is generated but is not copied in the unpacked folder
- the generated libs is renamed "main.js" but refers with a directive to a source map using the previous lib name (fastop/ op)
- the source map refers to the previous lib name (fastop/ op) but the libs has been renamed

What this PR does:
- remove the Chrome.defaultScripts helper. It means that the configuration, now, requires explicit List("main.js", "dependencies.js")
- restore the default ScalaJSPlugin behaviour on namings (with fastopt/ opt). It means that if no configuration is provided to override this behaviour, the lib will be named something like "extension-fastopt.js" when using chromeUnpackedFast
- adds the configuration to use to override this default behaviour in the examples. It means that there is a sample to let know how to get the previous behaviour (having "main.js" and "dependencies.js" files)
- copy the main lib source map to the unpacked folder, also copy the dependencies source map. These source maps are copied only if they exist.



